### PR TITLE
Option to support old compilers

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -66,7 +66,7 @@ var yargs = require("yargs")
             type: "boolean"
         },
         o: {
-            alias: "pre-c++11",
+            alias: "prec11",
             demand: false,
             describe: "do not force the c++11 flag, for compatibility with older systems",
             type: "boolean"

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -64,6 +64,12 @@ var yargs = require("yargs")
             demand: false,
             describe: "use GNU compiler even if Clang is available (Posix)",
             type: "boolean"
+        },
+        o: {
+            alias: "pre-c++11",
+            demand: false,
+            describe: "do not force the c++11 flag, for compatibility with older systems",
+            type: "boolean"
         }
 
     });
@@ -93,7 +99,8 @@ var options = {
     debug: argv.debug,
     cmakePath: argv.c || null,
     preferMake: argv.m,
-    preferGnu: argv.g
+    preferGnu: argv.g,
+    forceNoC11: argv.o
 };
 
 log.verbose("CON", "options:");

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -190,12 +190,14 @@ CMake.prototype.getConfigureCommand = function () {
 
                 // Mac
                 if (environment.isOSX) {
-                    D.push({ "CMAKE_CXX_FLAGS": "-D_DARWIN_USE_64_BIT_INODE=1 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DBUILDING_NODE_EXTENSION -w -std=c++11" });
+                    var cxxFlags = "-D_DARWIN_USE_64_BIT_INODE=1 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -DBUILDING_NODE_EXTENSION -w";
+                    if (!self.options.forceNoC11) cxxFlags += " -std=c++11";
+                    D.push({ "CMAKE_CXX_FLAGS": cxxFlags});
                     D.push({ "CMAKE_SHARED_LINKER_FLAGS": "-undefined dynamic_lookup" });
                 }
                 else if (!environment.isWin) {
                     // Other POSIX
-                    D.push({ "CMAKE_CXX_FLAGS": "-std=c++11" });
+                    if (!self.options.forceNoC11) D.push({ "CMAKE_CXX_FLAGS": "-std=c++11" });
                 }
 
                 command += " " +

--- a/tests/cMakeTests.js
+++ b/tests/cMakeTests.js
@@ -46,4 +46,16 @@ describe("CMake", function () {
             })
             .nodeify(done);
     });
+
+    it.only("should run with old compilers pre c++11", function (done) {
+        this.timeout(30000);
+        var cwd = process.cwd();
+        process.chdir(path.resolve(path.join(__dirname, "./prototype2")));
+        var cmake = new CMake({forceNoC11:true});
+        cmake.getConfigureCommand()
+            .then(function(command) {
+                assert.equal(command.indexOf("-std=c++11"), -1, "c++11 still forced");
+            })
+            .nodeify(done);
+    });
 });


### PR DESCRIPTION
Some older compilers might not support c++11.

Adding an option to remove the CXX flag that forces it.