### PR TITLE
Allow project runtime to be overriden

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ npm install -g cmake-js
 
 Please refer to the `--help` for the lists of available commands (they are like commands in `node-gyp`).
 
+You can override the project default runtimes via `--runtime` and `--runtime-version`, such as: `--runtime=electron --runtime-version=0.26.0`. See below for more info on runtimes.
+
 ### Runtimes
 
 You can configure runtimes for compiling target for all depending CMake.js modules in an application. Define a `cmake-js` key in the application's root `package.json` file, eg.:

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -77,7 +77,7 @@ var yargs = require("yargs")
            describe: "the runtime to use",
            type: "string" 
   	},
-        rv: {
+        v: {
            alias: "runtime-version",
            demand: false,
            describe: "the runtime version to use",
@@ -119,7 +119,7 @@ var options = {
     preferGnu: argv.g,
     forceNoC11: argv.o,
     runtime: argv.r,
-    runtimeVersion: argv.rv,
+    runtimeVersion: argv.v,
     arch: argv.A
 };
 

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -70,8 +70,19 @@ var yargs = require("yargs")
             demand: false,
             describe: "do not force the c++11 flag, for compatibility with older systems",
             type: "boolean"
+        },
+        r: {
+           alias: "runtime",
+           demand: false,
+           describe: "the runtime to use",
+           type: "string" 
+  	},
+        rv: {
+           alias: "runtime-version",
+           demand: false,
+           describe: "the runtime version to use",
+           type: "string"
         }
-
     });
 var argv = yargs.argv;
 
@@ -100,7 +111,9 @@ var options = {
     cmakePath: argv.c || null,
     preferMake: argv.m,
     preferGnu: argv.g,
-    forceNoC11: argv.o
+    forceNoC11: argv.o,
+    runtime: argv.r,
+    runtimeVersion: argv.rv
 };
 
 log.verbose("CON", "options:");

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -82,6 +82,12 @@ var yargs = require("yargs")
            demand: false,
            describe: "the runtime version to use",
            type: "string"
+        },
+        A: {
+           alias: "arch",
+           demand: false,
+           describe: "the architecture to build in",
+           type: "string"
         }
     });
 var argv = yargs.argv;
@@ -113,7 +119,8 @@ var options = {
     preferGnu: argv.g,
     forceNoC11: argv.o,
     runtime: argv.r,
-    runtimeVersion: argv.rv
+    runtimeVersion: argv.rv,
+    arch: argv.A
 };
 
 log.verbose("CON", "options:");

--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -16,7 +16,7 @@ function BuildSystem(options) {
         if (_.keys(appConfig).length) {
             this.log.info("CFG", "Applying CMake.js config from root package.json:");
             this.log.info("CFG", JSON.stringify(appConfig));
-            _.extend(this.options, appConfig);
+            this.options = _.extend(appConfig, this.options);
         }
     }
     this.log.verbose("CFG", "Build system options:");

--- a/lib/buildSystem.js
+++ b/lib/buildSystem.js
@@ -15,8 +15,9 @@ function BuildSystem(options) {
         delete appConfig.directory;
         if (_.keys(appConfig).length) {
             this.log.info("CFG", "Applying CMake.js config from root package.json:");
+            _.merge(appConfig,  _.pick(this.options,"runtime","runtimeVersion","arch")); // allow overriding of those properties
+            _.extend(this.options, appConfig); 
             this.log.info("CFG", JSON.stringify(appConfig));
-            this.options = _.extend(appConfig, this.options);
         }
     }
     this.log.verbose("CFG", "Build system options:");


### PR DESCRIPTION
A lot of projects can be used on multiple runtimes, e.g. between nw.js / electron. Also, most io.js / node.js projects can be used on nw.js / electron, so it doesn't fully make sense to have a project completely bound to a runtime.

I added the ability to over-ride runtime through command line arguments, which I think is absolutely essential for these reasons.
