### PR TITLE
Ability to generate Xcode Project with make-js

### DIFF
--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -59,6 +59,12 @@ var yargs = require("yargs")
             describe: "use Unix Makefiles even if Ninja is available (Posix)",
             type: "boolean"
         },
+        x : {
+            alias: "prefer-xcode",
+            demand: false,
+            describe: "use Xcode instead of Unix Makefiles",
+            type: "boolean"
+        },
         g: {
             alias: "prefer-gnu",
             demand: false,

--- a/bin/cmake-js
+++ b/bin/cmake-js
@@ -122,6 +122,7 @@ var options = {
     debug: argv.debug,
     cmakePath: argv.c || null,
     preferMake: argv.m,
+    preferXcode : argv.x,
     preferGnu: argv.g,
     forceNoC11: argv.o,
     runtime: argv.r,

--- a/lib/cMake.js
+++ b/lib/cMake.js
@@ -178,6 +178,7 @@ CMake.prototype.getConfigureCommand = function () {
 
     return init.then(function () {
         var useNinja = !environment.isWin && !self.options.preferMake && environment.isNinjaAvailable;
+        var useXcode = environment.isOSX && self.options.preferXcode;
         var command = self.path;
         command += " \"" + self.projectRoot + "\" --no-warn-unused-cli";
         if (useNinja) {
@@ -186,6 +187,10 @@ CMake.prototype.getConfigureCommand = function () {
         else if (vsGeneratorOverride) {
             command += " " + vsGeneratorOverride;
         }
+        else if (useXcode) {
+            command += " -GXcode";
+        }
+
         var D = [];
 
         // Build configuration:


### PR DESCRIPTION
The commit adds command variable to create Xcode project with CMAKE, really useful while debugging addons on MAC 

cmake-js build -x 
cmake-js rebuild -x 